### PR TITLE
Add bind mapper

### DIFF
--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -50,7 +50,7 @@ border-style=pipes
 # Default: 20
 sidebar-width=20
 
-[binds]
+[input]
 #Binds are of the form <key sequence> = <command to run>
 #To use '=' in a key sequence, substitute it with "Eq": "Ctrl+Eq"
 #If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit

--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -54,12 +54,12 @@ sidebar-width=20
 #Binds are of the form <key sequence> = <command to run>
 #To use '=' in a key sequence, substitute it with "Eq": "Ctrl+Eq"
 #If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit
-q = quit
-Ctrl+c = quit
-h = previous-mailbox
-j = next-message
-k = previous-message
-l = next-mailbox
+q = :quit<Enter>
+Ctrl+c = :quit<Enter>
+h = :previous-mailbox<Enter>
+j = :next-message<Enter>
+k = :previous-message<Enter>
+l = :next-mailbox<Enter>
 
 [colors]
 #

--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -50,6 +50,15 @@ border-style=pipes
 # Default: 20
 sidebar-width=20
 
+[binds]
+#Binds are of the form <key sequence> = <command to run>
+#To use '=' in a key sequence, substitute it with "Eq": "Ctrl+Eq"
+#If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit
+q = quit
+Ctrl+c = quit
+Ctrl+j = next-message
+Ctrl+k = previous-message
+
 [colors]
 #
 # Colors are configured in one of two ways:

--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -56,8 +56,10 @@ sidebar-width=20
 #If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit
 q = quit
 Ctrl+c = quit
-Ctrl+j = next-message
-Ctrl+k = previous-message
+h = previous-mailbox
+j = next-message
+k = previous-message
+l = next-mailbox
 
 [colors]
 #

--- a/include/bind.h
+++ b/include/bind.h
@@ -33,4 +33,7 @@ char* bind_input_buffer(struct bind* bind);
 //returns a string representing the key event, or NULL
 char* bind_translate_key_event(struct tb_event* event);
 
+//return an event representing the key name, or NULL
+struct tb_event* bind_translate_key_name(const char* key);
+
 #endif

--- a/include/bind.h
+++ b/include/bind.h
@@ -1,0 +1,36 @@
+#ifndef BIND_H
+#define BIND_H
+
+#include <termbox.h>
+
+#include "util/list.h"
+
+enum bind_result {
+	BIND_SUCCESS,
+	BIND_INVALID_KEYS,
+	BIND_INVALID_COMMAND,
+	BIND_CONFLICTS,
+};
+
+struct bind {
+	list_t *keys; //list of the keys pressed so far
+	void *binds;  //implementation
+};
+
+void init_bind(struct bind* bind);
+void destroy_bind(struct bind* bind);
+
+//Bind the given key combination to the given command
+enum bind_result bind_add(struct bind* bind, const char* keys, const char* command);
+
+//Handle a key-press event. If it results in a command, that command is
+//returned, otherwise NULL is returned.
+const char* bind_handle_key_event(struct bind* bind, struct tb_event* event);
+
+//Return a string representing the state of the input buffer
+char* bind_input_buffer(struct bind* bind);
+
+//returns a string representing the key event, or NULL
+char* bind_translate_key_event(struct tb_event* event);
+
+#endif

--- a/include/state.h
+++ b/include/state.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <time.h>
 
+#include "bind.h"
 #include "util/list.h"
 #include "worker.h"
 
@@ -44,6 +45,7 @@ struct aerc_state {
 		char *text;
 		size_t length, index, scroll;
 	} command;
+	struct bind *binds;
 };
 
 extern struct aerc_state *state;

--- a/include/state.h
+++ b/include/state.h
@@ -41,6 +41,7 @@ struct aerc_state {
 	size_t selected_account;
 	list_t *accounts;
 	bool exit;
+	bool rerender;
 	struct {
 		char *text;
 		size_t length, index, scroll;

--- a/include/tests.h
+++ b/include/tests.h
@@ -20,5 +20,6 @@ int __wrap_ab_recv(absocket_t *socket, void *buffer, size_t len);
 int run_tests_urlparse();
 int run_tests_imap();
 int run_tests_headers();
+int run_tests_bind();
 
 #endif

--- a/include/util/stringop.h
+++ b/include/util/stringop.h
@@ -19,6 +19,7 @@ void strip_quotes(char *str);
 
 // strcmp that also handles null pointers.
 int lenient_strcmp(char *a, char *b);
+int is_prefix_of(const char* prefix, const char* str);
 
 // Simply split a string with delims, free with `free_flat_list`
 list_t *split_string(const char *str, const char *delims);

--- a/src/bind.c
+++ b/src/bind.c
@@ -1,0 +1,410 @@
+#define _POSIX_C_SOURCE 201112LL
+
+#include <ctype.h>
+#include <malloc.h>
+#include <string.h>
+#include <termbox.h>
+
+#include "bind.h"
+#include "util/stringop.h"
+
+// bind_node is a node in a trie of all the valid binds
+struct bind_node {
+	char* key; // the key combination of this node
+	char* command; // if node is a leaf, the command, else NULL
+	list_t* suffixes; // the children of this node
+};
+
+static const char* valid_prefixes[] = {"Ctrl+", "Meta+"};
+static const char* valid_special_stubs[] = {
+	"Space",
+	"F1",
+	"F2",
+	"F3",
+	"F4",
+	"F5",
+	"F6",
+	"F7",
+	"F8",
+	"F9",
+	"F10",
+	"F11",
+	"F12",
+	"Left",
+	"Right",
+	"Up",
+	"Down",
+	"Enter",
+	"Backspace",
+	"PageUp",
+	"PageDown",
+	"Home",
+	"End",
+	"Tab",
+	"Insert",
+	"Delete",
+};
+
+static void init_bind_node(struct bind_node* bn)
+{
+	bn->key = NULL;
+	bn->command = NULL;
+	bn->suffixes = create_list();
+}
+
+static void destroy_bind_node(struct bind_node* bn)
+{
+	for(size_t i = 0; i < bn->suffixes->length; ++i)
+		destroy_bind_node(bn->suffixes->items[i]);
+	free(bn->key);
+	free(bn->command);
+	list_free(bn->suffixes);
+}
+
+static int is_valid_key(const char* key)
+{
+	//Advance past any valid prefixes like Ctrl+ or Meta+
+	for(size_t i = 0;
+	    i < sizeof valid_prefixes / sizeof valid_prefixes[0];
+	    ++i) {
+		if(is_prefix_of(valid_prefixes[i], key))
+			key += strlen(valid_prefixes[i]);
+	}
+
+	//Check Shift+ as well, but if it's used, only special stubs may follow
+	//to avoid Shift+W vs W tautology
+	int must_be_special = 0;
+	if(is_prefix_of("Shift+", key)) {
+		key += strlen("Shift+");
+		must_be_special = 1;
+	}
+
+	//Check if we're left with a valid regular key stub
+	if(!must_be_special) {
+		//Anything printable is valid, except '=' which can't go in a .ini file
+		if(strlen(key) == 1 && isgraph(*key) && *key != '=')
+			return 1;
+
+		//Special case: 'Eq' as a alias for '='
+		if(strcmp(key, "Eq") == 0)
+			return 1;
+	}
+
+	//Maybe it's a special stub
+	for(size_t i = 0;
+		i < sizeof valid_special_stubs / sizeof valid_special_stubs[0];
+		++i) {
+		//Not one of our special stubs? Can only be invalid.
+		if(strcmp(valid_special_stubs[i], key) == 0)
+			return 1;
+	}
+
+	return 0;
+}
+
+static int is_valid_keys(const char* keys)
+{
+	if(!keys || strlen(keys) == 0)
+		return 0;
+
+	int valid = 1;
+	list_t *parts = split_string(keys," ");
+
+	for(size_t i = 0; i < parts->length; ++i)
+	{
+		if(!is_valid_key(parts->items[i])) {
+			valid = 0;
+			break;
+		}
+	}
+
+	free_flat_list(parts);
+	return valid;
+}
+
+void init_bind(struct bind* bind)
+{
+	bind->keys = create_list();
+	bind->binds = malloc(sizeof(struct bind_node));
+	init_bind_node(bind->binds);
+}
+
+void destroy_bind(struct bind* bind)
+{
+	destroy_bind_node(bind->binds);
+	free(bind->binds);
+}
+
+static int compare_node_key(const struct bind_node* node, const char *key)
+{
+	return strcmp(node->key,key);
+}
+
+enum bind_result bind_add(struct bind* bind, const char* keys, const char* command)
+{
+	if(!command)
+		return BIND_INVALID_COMMAND;
+
+	if(!keys)
+		return BIND_INVALID_KEYS;
+
+	char* dirty_keys = strdup(keys);
+	strip_quotes(dirty_keys);
+
+	if(!is_valid_keys(keys)) {
+		free(dirty_keys);
+		return BIND_INVALID_KEYS;
+	}
+
+	// Split the key up into its individual parts
+	list_t *parts = split_string(dirty_keys, " ");
+
+	//Prepare our return code
+	int result = BIND_SUCCESS;
+
+	// Traverse the trie
+	struct bind_node *node = bind->binds;
+	for(size_t i = 0; i < parts->length; ++i) {
+		//If we've reached a node that already has a command, there's a conflict
+		if(node->command) {
+			result = BIND_INVALID_COMMAND;
+			break;
+		}
+
+		//Find / create a child with the current key
+		struct bind_node *next_node = NULL;
+		int child_index = list_seq_find(node->suffixes, (void*)&compare_node_key, parts->items[i]);
+		if(child_index == -1) {
+			//Create our new node
+			next_node = malloc(sizeof(struct bind_node));
+			init_bind_node(next_node);
+			next_node->key = strdup(parts->items[i]);
+			list_add(node->suffixes, next_node);
+		} else {
+			next_node = node->suffixes->items[child_index];
+		}
+
+		//We've now found the correct node for this key
+
+		//Check if the node has a command
+		if(next_node->command) {
+			if(i + 1 < parts->length) {
+				//If we're not at the end, it's a conflict
+				result = BIND_CONFLICTS;
+				break;
+			} else {
+				//Otherwise we just need to overwrite the existing bind.
+				next_node->command = strdup(command);
+				result = BIND_SUCCESS;
+				break;
+			}
+		}
+
+		if(i + 1 == parts->length) {
+			//this is the last key part, try to insert command
+			//but first, make sure there's no children
+			if(next_node->suffixes->length > 0) {
+				result = BIND_CONFLICTS;
+			} else {
+				next_node->command = strdup(command);
+			}
+		} else {
+			//Otherwise, move down the trie
+			node = next_node;
+		}
+	}
+
+	free(dirty_keys);
+	free_flat_list(parts);
+	return result;
+}
+
+static int print_event(char* buf, size_t len, struct tb_event* event)
+{
+	const char* str = NULL;
+
+	//Build prefix first:
+	const char *prefix = event->mod & TB_MOD_ALT ? "Meta+" : "";
+
+	//Try plain old character input
+	if(event->ch) {
+		//Alias '=' into Eq, and ' ' into Space
+		if(event->ch == '=')
+			return snprintf(buf, len, "%sEq", prefix);
+		else if(event->ch == ' ')
+			return snprintf(buf, len, "%sSpace", prefix);
+		else
+			return snprintf(buf, len, "%s%c", prefix, event->ch);
+	}
+
+	//Try the first set of special keys
+	switch(event->key) {
+		case TB_KEY_F1:          str = "F1";        break;
+		case TB_KEY_F2:          str = "F2";        break;
+		case TB_KEY_F3:          str = "F3";        break;
+		case TB_KEY_F4:          str = "F4";        break;
+		case TB_KEY_F5:          str = "F5";        break;
+		case TB_KEY_F6:          str = "F6";        break;
+		case TB_KEY_F7:          str = "F7";        break;
+		case TB_KEY_F8:          str = "F8";        break;
+		case TB_KEY_F9:          str = "F9";        break;
+		case TB_KEY_F10:         str = "F10";       break;
+		case TB_KEY_F11:         str = "F11";       break;
+		case TB_KEY_F12:         str = "F12";       break;
+		case TB_KEY_INSERT:      str = "Insert";    break;
+		case TB_KEY_DELETE:      str = "Delete";    break;
+		case TB_KEY_HOME:        str = "Home";      break;
+		case TB_KEY_END:         str = "End";       break;
+		case TB_KEY_PGUP:        str = "PageUp";    break;
+		case TB_KEY_PGDN:        str = "PageDown";  break;
+		case TB_KEY_ARROW_UP:    str = "Up";        break;
+		case TB_KEY_ARROW_DOWN:  str = "Down";      break;
+		case TB_KEY_ARROW_LEFT:  str = "Left";      break;
+		case TB_KEY_ARROW_RIGHT: str = "Right";     break;
+		case TB_KEY_SPACE:       str = "Space";     break;
+		case TB_KEY_TAB:         str = "Tab";       break;
+		case TB_KEY_BACKSPACE:
+		case TB_KEY_BACKSPACE2:  str = "Backspace"; break;
+		case TB_KEY_ENTER:       str = "Enter";     break;
+	}
+
+	//Was it one of the special keys?
+	if(str) {
+		return snprintf(buf, len, "%s%s", prefix, str);
+	}
+
+	//Other special, hardcoded cases
+	switch(event->key) {
+		case TB_KEY_CTRL_TILDE:       str = "Ctrl+~";  break;
+		case TB_KEY_CTRL_A:           str = "Ctrl+a";  break;
+		case TB_KEY_CTRL_B:           str = "Ctrl+b";  break;
+		case TB_KEY_CTRL_C:           str = "Ctrl+c";  break;
+		case TB_KEY_CTRL_D:           str = "Ctrl+d";  break;
+		case TB_KEY_CTRL_E:           str = "Ctrl+e";  break;
+		case TB_KEY_CTRL_F:           str = "Ctrl+f";  break;
+		case TB_KEY_CTRL_G:           str = "Ctrl+g";  break;
+		case TB_KEY_CTRL_H:           str = "Ctrl+h";  break;
+		case TB_KEY_CTRL_I:           str = "Ctrl+i";  break;
+		case TB_KEY_CTRL_J:           str = "Ctrl+j";  break;
+		case TB_KEY_CTRL_K:           str = "Ctrl+k";  break;
+		case TB_KEY_CTRL_L:           str = "Ctrl+l";  break;
+		case TB_KEY_CTRL_M:           str = "Ctrl+m";  break;
+		case TB_KEY_CTRL_N:           str = "Ctrl+n";  break;
+		case TB_KEY_CTRL_O:           str = "Ctrl+o";  break;
+		case TB_KEY_CTRL_P:           str = "Ctrl+p";  break;
+		case TB_KEY_CTRL_Q:           str = "Ctrl+q";  break;
+		case TB_KEY_CTRL_R:           str = "Ctrl+r";  break;
+		case TB_KEY_CTRL_S:           str = "Ctrl+s";  break;
+		case TB_KEY_CTRL_T:           str = "Ctrl+t";  break;
+		case TB_KEY_CTRL_U:           str = "Ctrl+u";  break;
+		case TB_KEY_CTRL_V:           str = "Ctrl+v";  break;
+		case TB_KEY_CTRL_W:           str = "Ctrl+w";  break;
+		case TB_KEY_CTRL_X:           str = "Ctrl+x";  break;
+		case TB_KEY_CTRL_Y:           str = "Ctrl+y";  break;
+		case TB_KEY_CTRL_Z:           str = "Ctrl+z";  break;
+		case TB_KEY_CTRL_LSQ_BRACKET: str = "Ctrl+[";  break;
+		case TB_KEY_CTRL_RSQ_BRACKET: str = "Ctrl+]";  break;
+		case TB_KEY_CTRL_BACKSLASH:   str = "Ctrl+\\"; break;
+		case TB_KEY_CTRL_SLASH:       str = "Ctrl+/";  break;
+	}
+
+	if(str) {
+		return snprintf(buf, len, "%s", str);
+	}
+
+	//No idea
+	buf[0] = 0;
+	return 0;
+}
+
+enum lookup_result {
+	LOOKUP_PARTIAL,
+	LOOKUP_INVALID,
+	LOOKUP_MATCH,
+};
+
+static enum lookup_result lookup_binding(struct bind_node* node, list_t* keys, const char** out_str)
+{
+	//Iterate through the list of inputs (e.g. Ctrl+a b)
+	for(size_t part = 0; part < keys->length; ++part) {
+		//Look for a child that matches the next input part (e.g. Ctrl+a)
+		const char* cur_key = keys->items[part];
+		int found = 0;
+		for(size_t i = 0; i < node->suffixes->length; ++i) {
+			struct bind_node* cur_node = node->suffixes->items[i];
+			if(strcmp(cur_node->key, cur_key) == 0) {
+				//We found a match, move down the trie to the next level
+				node = node->suffixes->items[i];
+				found = 1;
+				break;
+			}
+		}
+		// Did we reach this point without finding a match? Abort.
+		if(!found)
+			return LOOKUP_INVALID;
+	}
+
+	//We've reached the end, if node has a command, it's a match, if not, it's
+	//a partial.
+	if(node->command) {
+		*out_str = node->command;
+		return LOOKUP_MATCH;
+	}
+	return LOOKUP_PARTIAL;
+}
+
+char* bind_input_buffer(struct bind* bind)
+{
+	return join_list(bind->keys, " ");
+}
+
+static void clear_input_buffer(struct bind* bind)
+{
+		free_flat_list(bind->keys);
+		bind->keys = create_list();
+}
+
+const char* bind_handle_key_event(struct bind* bind, struct tb_event* event)
+{
+	//If the user hit ESC, clear the input buffer and abort
+	if(event->key == TB_KEY_ESC) {
+		clear_input_buffer(bind);
+		return NULL;
+	}
+
+	//Turn the key event into a representative string
+	char buffer[128];
+	print_event(buffer, sizeof buffer, event);
+
+	//Add it to our input list
+	list_add(bind->keys, strdup(buffer));
+
+	//Check if it means anything
+	const char* command = NULL;
+	enum lookup_result result = lookup_binding(bind->binds, bind->keys, &command);
+	if(result == LOOKUP_PARTIAL) {
+		//We need more input.
+		return NULL;
+	} else if(result == LOOKUP_MATCH) {
+		//We found a command. Clear our input buffer, and return it.
+		clear_input_buffer(bind);
+		return command;
+	} else if(result == LOOKUP_INVALID) {
+		//No such command. Clear input buffer and abort.
+		clear_input_buffer(bind);
+		return NULL;
+	}
+
+	// Shouldn't reach this point ever, so clean up and reset as a precaution.
+	clear_input_buffer(bind);
+	return NULL;
+}
+
+char* bind_translate_key_event(struct tb_event* event)
+{
+	char buf[32];
+	if(print_event(buf, sizeof buf, event))
+		return strdup(buf);
+	else
+		return NULL;
+}

--- a/src/bind.c
+++ b/src/bind.c
@@ -45,6 +45,69 @@ static const char* valid_special_stubs[] = {
 	"Delete",
 };
 
+static const struct {
+	const char* name;
+	int key;
+} key_name_pairs[] = {
+	{"F1", TB_KEY_F1},
+	{"F2", TB_KEY_F2},
+	{"F3", TB_KEY_F3},
+	{"F4", TB_KEY_F4},
+	{"F5", TB_KEY_F5},
+	{"F6", TB_KEY_F6},
+	{"F7", TB_KEY_F7},
+	{"F8", TB_KEY_F8},
+	{"F9", TB_KEY_F9},
+	{"F10", TB_KEY_F10},
+	{"F11", TB_KEY_F11},
+	{"F12", TB_KEY_F12},
+	{"Left", TB_KEY_ARROW_LEFT},
+	{"Right", TB_KEY_ARROW_RIGHT},
+	{"Up", TB_KEY_ARROW_UP},
+	{"Down", TB_KEY_ARROW_DOWN},
+	{"Enter", TB_KEY_ENTER},
+	{"Backspace", TB_KEY_BACKSPACE},
+	{"Backspace", TB_KEY_BACKSPACE2},
+	{"PageUp", TB_KEY_PGUP},
+	{"PageDown", TB_KEY_PGDN},
+	{"Home", TB_KEY_HOME},
+	{"End", TB_KEY_END},
+	{"Tab", TB_KEY_TAB},
+	{"Insert", TB_KEY_INSERT},
+	{"Delete", TB_KEY_DELETE},
+	{"Ctrl+~", TB_KEY_CTRL_TILDE},
+	{"Ctrl+a", TB_KEY_CTRL_A},
+	{"Ctrl+b", TB_KEY_CTRL_B},
+	{"Ctrl+c", TB_KEY_CTRL_C},
+	{"Ctrl+d", TB_KEY_CTRL_D},
+	{"Ctrl+e", TB_KEY_CTRL_E},
+	{"Ctrl+f", TB_KEY_CTRL_F},
+	{"Ctrl+g", TB_KEY_CTRL_G},
+	{"Ctrl+h", TB_KEY_CTRL_H},
+	{"Ctrl+i", TB_KEY_CTRL_I},
+	{"Ctrl+j", TB_KEY_CTRL_J},
+	{"Ctrl+k", TB_KEY_CTRL_K},
+	{"Ctrl+l", TB_KEY_CTRL_L},
+	{"Ctrl+m", TB_KEY_CTRL_M},
+	{"Ctrl+n", TB_KEY_CTRL_N},
+	{"Ctrl+o", TB_KEY_CTRL_O},
+	{"Ctrl+p", TB_KEY_CTRL_P},
+	{"Ctrl+q", TB_KEY_CTRL_Q},
+	{"Ctrl+r", TB_KEY_CTRL_R},
+	{"Ctrl+s", TB_KEY_CTRL_S},
+	{"Ctrl+t", TB_KEY_CTRL_T},
+	{"Ctrl+u", TB_KEY_CTRL_U},
+	{"Ctrl+v", TB_KEY_CTRL_V},
+	{"Ctrl+w", TB_KEY_CTRL_W},
+	{"Ctrl+x", TB_KEY_CTRL_X},
+	{"Ctrl+y", TB_KEY_CTRL_Y},
+	{"Ctrl+z", TB_KEY_CTRL_Z},
+	{"Ctrl+[", TB_KEY_CTRL_LSQ_BRACKET},
+	{"Ctrl+]", TB_KEY_CTRL_RSQ_BRACKET},
+	{"Ctrl+\\", TB_KEY_CTRL_BACKSLASH},
+	{"Ctrl+/", TB_KEY_CTRL_SLASH},
+};
+
 static void init_bind_node(struct bind_node* bn)
 {
 	bn->key = NULL;
@@ -237,82 +300,19 @@ static int print_event(char* buf, size_t len, struct tb_event* event)
 			return snprintf(buf, len, "%s%c", prefix, event->ch);
 	}
 
-	//Try the first set of special keys
-	switch(event->key) {
-		case TB_KEY_F1:          str = "F1";        break;
-		case TB_KEY_F2:          str = "F2";        break;
-		case TB_KEY_F3:          str = "F3";        break;
-		case TB_KEY_F4:          str = "F4";        break;
-		case TB_KEY_F5:          str = "F5";        break;
-		case TB_KEY_F6:          str = "F6";        break;
-		case TB_KEY_F7:          str = "F7";        break;
-		case TB_KEY_F8:          str = "F8";        break;
-		case TB_KEY_F9:          str = "F9";        break;
-		case TB_KEY_F10:         str = "F10";       break;
-		case TB_KEY_F11:         str = "F11";       break;
-		case TB_KEY_F12:         str = "F12";       break;
-		case TB_KEY_INSERT:      str = "Insert";    break;
-		case TB_KEY_DELETE:      str = "Delete";    break;
-		case TB_KEY_HOME:        str = "Home";      break;
-		case TB_KEY_END:         str = "End";       break;
-		case TB_KEY_PGUP:        str = "PageUp";    break;
-		case TB_KEY_PGDN:        str = "PageDown";  break;
-		case TB_KEY_ARROW_UP:    str = "Up";        break;
-		case TB_KEY_ARROW_DOWN:  str = "Down";      break;
-		case TB_KEY_ARROW_LEFT:  str = "Left";      break;
-		case TB_KEY_ARROW_RIGHT: str = "Right";     break;
-		case TB_KEY_SPACE:       str = "Space";     break;
-		case TB_KEY_TAB:         str = "Tab";       break;
-		case TB_KEY_BACKSPACE:
-		case TB_KEY_BACKSPACE2:  str = "Backspace"; break;
-		case TB_KEY_ENTER:       str = "Enter";     break;
+	//Try to find a special key
+	for(size_t i = 0; i < sizeof key_name_pairs / sizeof *key_name_pairs; ++i) {
+		if(event->key == key_name_pairs[i].key) {
+			str = key_name_pairs[i].name;
+			break;
+		}
 	}
-
 	//Was it one of the special keys?
 	if(str) {
 		return snprintf(buf, len, "%s%s", prefix, str);
 	}
 
-	//Other special, hardcoded cases
-	switch(event->key) {
-		case TB_KEY_CTRL_TILDE:       str = "Ctrl+~";  break;
-		case TB_KEY_CTRL_A:           str = "Ctrl+a";  break;
-		case TB_KEY_CTRL_B:           str = "Ctrl+b";  break;
-		case TB_KEY_CTRL_C:           str = "Ctrl+c";  break;
-		case TB_KEY_CTRL_D:           str = "Ctrl+d";  break;
-		case TB_KEY_CTRL_E:           str = "Ctrl+e";  break;
-		case TB_KEY_CTRL_F:           str = "Ctrl+f";  break;
-		case TB_KEY_CTRL_G:           str = "Ctrl+g";  break;
-		case TB_KEY_CTRL_H:           str = "Ctrl+h";  break;
-		case TB_KEY_CTRL_I:           str = "Ctrl+i";  break;
-		case TB_KEY_CTRL_J:           str = "Ctrl+j";  break;
-		case TB_KEY_CTRL_K:           str = "Ctrl+k";  break;
-		case TB_KEY_CTRL_L:           str = "Ctrl+l";  break;
-		case TB_KEY_CTRL_M:           str = "Ctrl+m";  break;
-		case TB_KEY_CTRL_N:           str = "Ctrl+n";  break;
-		case TB_KEY_CTRL_O:           str = "Ctrl+o";  break;
-		case TB_KEY_CTRL_P:           str = "Ctrl+p";  break;
-		case TB_KEY_CTRL_Q:           str = "Ctrl+q";  break;
-		case TB_KEY_CTRL_R:           str = "Ctrl+r";  break;
-		case TB_KEY_CTRL_S:           str = "Ctrl+s";  break;
-		case TB_KEY_CTRL_T:           str = "Ctrl+t";  break;
-		case TB_KEY_CTRL_U:           str = "Ctrl+u";  break;
-		case TB_KEY_CTRL_V:           str = "Ctrl+v";  break;
-		case TB_KEY_CTRL_W:           str = "Ctrl+w";  break;
-		case TB_KEY_CTRL_X:           str = "Ctrl+x";  break;
-		case TB_KEY_CTRL_Y:           str = "Ctrl+y";  break;
-		case TB_KEY_CTRL_Z:           str = "Ctrl+z";  break;
-		case TB_KEY_CTRL_LSQ_BRACKET: str = "Ctrl+[";  break;
-		case TB_KEY_CTRL_RSQ_BRACKET: str = "Ctrl+]";  break;
-		case TB_KEY_CTRL_BACKSLASH:   str = "Ctrl+\\"; break;
-		case TB_KEY_CTRL_SLASH:       str = "Ctrl+/";  break;
-	}
-
-	if(str) {
-		return snprintf(buf, len, "%s", str);
-	}
-
-	//No idea
+	//No idea what it's meant to be - give up
 	buf[0] = 0;
 	return 0;
 }
@@ -407,4 +407,19 @@ char* bind_translate_key_event(struct tb_event* event)
 		return strdup(buf);
 	else
 		return NULL;
+}
+
+struct tb_event* bind_translate_key_name(const char* key)
+{
+	for(size_t i = 0; i < sizeof key_name_pairs / sizeof *key_name_pairs; ++i) {
+		if(strcmp(key_name_pairs[i].name, key) == 0) {
+			struct tb_event* e = calloc(1, sizeof(struct tb_event));
+			e->type = TB_EVENT_KEY;
+			e->key = key_name_pairs[i].key;
+			return e;
+		}
+	}
+
+	//No matches, give up
+	return NULL;
 }

--- a/src/bind.c
+++ b/src/bind.c
@@ -411,10 +411,38 @@ char* bind_translate_key_event(struct tb_event* event)
 
 struct tb_event* bind_translate_key_name(const char* key)
 {
+	int meta = 0;
+	//Check for 'Meta+' prefix
+	if(is_prefix_of("Meta+", key)) {
+		meta = 1;
+		key += strlen("Meta+");
+	}
+
+
+	//Check if we've got 'Meta+' and a regular keypress
+	if(meta == 1) {
+		//Alias Eq and Space
+		if(strcmp(key, "Eq") == 0) {
+			key = "=";
+		} else if(strcmp(key, "Space") == 0) {
+			key = " ";
+		}
+
+		//If we've only got a single character - it was a regular keypress
+		if(strlen(key) == 1) {
+			struct tb_event* e = calloc(1, sizeof(struct tb_event));
+			e->type = TB_EVENT_KEY;
+			e->mod = TB_MOD_ALT; //We're always 'meta' at this point
+			e->ch = key[0];
+			return e;
+		}
+	}
+
 	for(size_t i = 0; i < sizeof key_name_pairs / sizeof *key_name_pairs; ++i) {
 		if(strcmp(key_name_pairs[i].name, key) == 0) {
 			struct tb_event* e = calloc(1, sizeof(struct tb_event));
 			e->type = TB_EVENT_KEY;
+			e->mod = meta ? TB_MOD_ALT : 0;
 			e->key = key_name_pairs[i].key;
 			return e;
 		}

--- a/src/commands.c
+++ b/src/commands.c
@@ -34,6 +34,18 @@ static void handle_previous_message(int argc, char **argv) {
 	}
 }
 
+static void handle_next_mailbox(int argc, char **argv) {
+	state->selected_account++;
+	state->selected_account %= state->accounts->length;
+	rerender();
+}
+
+static void handle_previous_mailbox(int argc, char **argv) {
+	state->selected_account--;
+	state->selected_account %= state->accounts->length;
+	rerender();
+}
+
 static void handle_cd(int argc, char **argv) {
 	struct account_state *account =
 		state->accounts->items[state->selected_account];
@@ -65,7 +77,9 @@ struct cmd_handler cmd_handlers[] = {
 	{ "cd", handle_cd },
 	{ "delete-mailbox", handle_delete_mailbox },
 	{ "exit", handle_quit },
+	{ "next-mailbox", handle_next_mailbox },
 	{ "next-message", handle_next_message },
+	{ "previous-mailbox", handle_previous_mailbox },
 	{ "previous-message", handle_previous_message },
 	{ "q", handle_quit },
 	{ "quit", handle_quit }

--- a/src/config.c
+++ b/src/config.c
@@ -114,7 +114,7 @@ static int handle_config_option(void *_config, const char *section,
 		return 1;
 	}
 
-	if (strcmp(section, "binds") == 0) {
+	if (strcmp(section, "input") == 0) {
 		enum bind_result result = bind_add(state->binds, key, value);
 		// Check whether the bind worked
 		if(result == BIND_INVALID_KEYS) {

--- a/src/config.c
+++ b/src/config.c
@@ -22,9 +22,11 @@
 #include "util/stringop.h"
 #include "util/ini.h"
 #include "util/list.h"
+#include "bind.h"
 #include "colors.h"
 #include "log.h"
 #include "config.h"
+#include "state.h"
 
 struct aerc_config *config = NULL;
 
@@ -109,6 +111,22 @@ static int handle_config_option(void *_config, const char *section,
 
 	if (strcmp(section, "colors") == 0) {
 		set_color(key, value);
+		return 1;
+	}
+
+	if (strcmp(section, "binds") == 0) {
+		enum bind_result result = bind_add(state->binds, key, value);
+		// Check whether the bind worked
+		if(result == BIND_INVALID_KEYS) {
+			worker_log(L_ERROR, "Invalid bind key: %s", key);
+			return 0;
+		} else if(result == BIND_INVALID_COMMAND) {
+			worker_log(L_ERROR, "Invalid bind command: %s", value);
+			return 0;
+		} else if(result == BIND_CONFLICTS) {
+			worker_log(L_ERROR, "Bind conflicts with an existing bind: %s", key);
+			return 0;
+		}
 		return 1;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -65,12 +65,12 @@ static void init_state() {
 	init_bind(state->binds);
 
 	//Hardcode some default binds for now
-	bind_add(state->binds, "q", "quit");
-	bind_add(state->binds, "Ctrl+c", "quit");
-	bind_add(state->binds, "h", "previous-mailbox");
-	bind_add(state->binds, "j", "next-message");
-	bind_add(state->binds, "k", "previous-message");
-	bind_add(state->binds, "l", "next-mailbox");
+	bind_add(state->binds, "q", ":quit<Enter>");
+	bind_add(state->binds, "Ctrl+c", ":quit<Enter>");
+	bind_add(state->binds, "h", ":previous-mailbox<Enter>");
+	bind_add(state->binds, "j", ":next-message<Enter>");
+	bind_add(state->binds, "k", ":previous-message<Enter>");
+	bind_add(state->binds, "l", ":next-mailbox<Enter>");
 }
 
 static void cleanup_state() {

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "absocket.h"
+#include "bind.h"
 #include "colors.h"
 #include "config.h"
 #include "handlers.h"
@@ -20,6 +21,7 @@
 #include "state.h"
 #include "ui.h"
 #include "util/list.h"
+#include "util/stringop.h"
 
 struct aerc_state *state;
 
@@ -56,9 +58,24 @@ void handle_worker_message(struct account_state *account, struct worker_message 
 	}
 }
 
-void init_state() {
+static void init_state() {
 	state = calloc(1, sizeof(struct aerc_state));
 	state->accounts = create_list();
+	state->binds = malloc(sizeof(struct bind));
+	init_bind(state->binds);
+
+	//Hardcode some default binds for now
+	bind_add(state->binds, "q", "quit");
+	bind_add(state->binds, "Ctrl+c", "quit");
+	bind_add(state->binds, "Ctrl+j", "next-message");
+	bind_add(state->binds, "Ctrl+k", "previous-message");
+}
+
+static void cleanup_state() {
+	destroy_bind(state->binds);
+	free_flat_list(state->accounts);
+	free(state->command.text);
+	free(state);
 }
 
 int main(int argc, char **argv) {
@@ -125,5 +142,6 @@ int main(int argc, char **argv) {
 	}
 
 	teardown_ui();
+	cleanup_state();
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -67,8 +67,10 @@ static void init_state() {
 	//Hardcode some default binds for now
 	bind_add(state->binds, "q", "quit");
 	bind_add(state->binds, "Ctrl+c", "quit");
-	bind_add(state->binds, "Ctrl+j", "next-message");
-	bind_add(state->binds, "Ctrl+k", "previous-message");
+	bind_add(state->binds, "h", "previous-mailbox");
+	bind_add(state->binds, "j", "next-message");
+	bind_add(state->binds, "k", "previous-message");
+	bind_add(state->binds, "l", "next-mailbox");
 }
 
 static void cleanup_state() {

--- a/src/render.c
+++ b/src/render.c
@@ -1,3 +1,4 @@
+#include <malloc.h>
 #include <string.h>
 #include <termbox.h>
 #include <time.h>
@@ -121,11 +122,29 @@ static void render_command(int x, int y, int width) {
 	tb_printf(x, y, &cell, ":%s", state->command.text);
 }
 
+static void render_partial_input(int x, int y, int width, const char* input) {
+	struct tb_cell cell;
+	get_color("ex-line", &cell);
+	cell.ch = ' ';
+	for (int _x = 0; _x < width; ++_x) {
+		tb_put_cell(x + _x, y, &cell);
+	}
+	tb_printf(x, y, &cell, "> %s", input);
+}
+
 void render_status(int x, int y, int width) {
 	if (state->command.text != NULL) {
 		render_command(x, y, width);
 		return;
 	}
+
+	char* input = bind_input_buffer(state->binds);
+	if(strlen(input) > 0) {
+		render_partial_input(x, y, width, input);
+		free(input);
+		return;
+	}
+	free(input);
 
 	struct account_state *account =
 		state->accounts->items[state->selected_account];

--- a/src/ui.c
+++ b/src/ui.c
@@ -226,27 +226,17 @@ bool ui_tick() {
 				state->command.index = 0;
 				state->command.scroll = 0;
 				rerender();
+			} else {
+				// Send input to bind mapper
+				const char* command = bind_handle_key_event(state->binds, &event);
+				if(command) {
+					//Handle any generated commands
+					handle_command(command);
+				}
 			}
-			// Temporary:
-			if (event.ch == 'q' || event.key == TB_KEY_CTRL_C) {
-				return false;
-			}
-			if (event.key == TB_KEY_ARROW_RIGHT) {
-				state->selected_account++;
-				state->selected_account %= state->accounts->length;
-				rerender();
-			}
-			if (event.key == TB_KEY_ARROW_LEFT) {
-				state->selected_account--;
-				state->selected_account %= state->accounts->length;
-				rerender();
-			}
-			// /temporary
-		}
 		if (event.key == TB_KEY_CTRL_L) {
 			rerender();
 		}
-		// TODO: Handle other keys
 		break;
 	case -1:
 		return false;

--- a/src/ui.c
+++ b/src/ui.c
@@ -225,7 +225,6 @@ bool ui_tick() {
 				state->command.length = 1024;
 				state->command.index = 0;
 				state->command.scroll = 0;
-				rerender();
 			} else {
 				// Send input to bind mapper
 				const char* command = bind_handle_key_event(state->binds, &event);
@@ -234,7 +233,6 @@ bool ui_tick() {
 					handle_command(command);
 				}
 			}
-		if (event.key == TB_KEY_CTRL_L) {
 			rerender();
 		}
 		break;

--- a/src/util/stringop.c
+++ b/src/util/stringop.c
@@ -49,6 +49,14 @@ void strip_quotes(char *str) {
 	*end = '\0';
 }
 
+int is_prefix_of(const char* prefix, const char* str) {
+	while(*prefix) {
+		if(*prefix++ != *str++)
+			return 0;
+	}
+	return 1;
+}
+
 list_t *split_string(const char *str, const char *delims) {
 	/*
 	 * Splits up a string at each delimiter, and returns a list_t with the

--- a/src/util/stringop.c
+++ b/src/util/stringop.c
@@ -180,6 +180,10 @@ char *join_list(list_t *list, char *separator) {
 		len += strlen(list->items[i]);
 	}
 
+	if(len == 0) {
+		return strdup("");
+	}
+
 	char *res = malloc(len);
 
 	char *p = res + strlen(list->items[0]);

--- a/test/bind.c
+++ b/test/bind.c
@@ -121,6 +121,36 @@ static void test_translate_key_event(void **state)
 	}
 }
 
+static void test_translate_key_name(void **state)
+{
+	struct {
+		const char* str;
+		char ch;
+		int mod;
+		int key;
+	} pairs[] = {
+		{"Ctrl+a", 0, 0, TB_KEY_CTRL_A},
+		{"Left", 0, 0, TB_KEY_ARROW_LEFT},
+		{"Meta+Right", 0, TB_MOD_ALT, TB_KEY_ARROW_RIGHT},
+		{"Meta+j", 'j', TB_MOD_ALT, 0},
+	};
+
+	struct tb_event e;
+	memset(&e, 0, sizeof e);
+	for(size_t i = 0; i < sizeof pairs / sizeof pairs[0]; ++i) {
+		/* e = generate_event(pairs[i].ch, pairs[i].mod, pairs[i].key); */
+		struct tb_event* event = bind_translate_key_name(pairs[i].str);
+		assert_non_null(event);
+
+		//Check the parts of the event we care about
+		assert_int_equal(event->ch, pairs[i].ch);
+		assert_int_equal(event->mod, pairs[i].mod);
+		assert_int_equal(event->key, pairs[i].key);
+
+		free(event);
+	}
+}
+
 static void test_get_input_buffer(void **state)
 {
 	struct bind bind;
@@ -190,6 +220,7 @@ int run_tests_bind() {
 		cmocka_unit_test(test_accept_valid_keys),
 		cmocka_unit_test(test_reject_conflicting_keys),
 		cmocka_unit_test(test_translate_key_event),
+		cmocka_unit_test(test_translate_key_name),
 		cmocka_unit_test(test_get_input_buffer),
 		cmocka_unit_test(test_remember_binds),
 	};

--- a/test/bind.c
+++ b/test/bind.c
@@ -1,0 +1,197 @@
+#include <malloc.h>
+#include <string.h>
+
+#include "tests.h"
+#include "bind.h"
+
+static struct tb_event generate_event(int ch, int mod, int key)
+{
+	struct tb_event e;
+	memset(&e, 0, sizeof e);
+	e.ch = ch;
+	e.mod = mod;
+	e.key = key;
+	return e;
+}
+
+static void test_reject_invalid_command(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	assert_int_equal(BIND_INVALID_COMMAND, bind_add(&bind, "Ctrl+n", NULL));
+
+	destroy_bind(&bind);
+}
+
+static void test_reject_invalid_keys(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	static const char* keys[] = {
+		"Ctrl+=",
+		"foobar",
+		"=",
+		"",
+		"Shift+W",
+		"Shift+Eq",
+		"Ctrl+Ctrl+x",
+	};
+
+	for(size_t i = 0; i < sizeof keys / sizeof keys[0]; ++i)
+		assert_int_equal(BIND_INVALID_KEYS, bind_add(&bind, keys[i], "command"));
+
+	destroy_bind(&bind);
+}
+
+static void test_accept_valid_keys(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	static const char* keys[] = {
+		"Ctrl+q",
+		"Ctrl+E",
+		"Meta+!",
+		"Space",
+		"Ctrl++",
+		"Ctrl+Eq",
+		"# 2",
+		"Ctrl+x s",
+		"Ctrl+x z",
+		"s",
+		"W",
+		"Ctrl+Meta+Delete",
+		";",
+		"F1",
+		"Meta+Backspace",
+		"Shift+Left",
+	};
+
+	for(size_t i = 0; i < sizeof keys / sizeof keys[0]; ++i)
+		assert_int_equal(BIND_SUCCESS, bind_add(&bind, keys[i], "command"));
+
+	destroy_bind(&bind);
+}
+
+static void test_reject_conflicting_keys(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b", "command"));
+
+	//Conflict if it's a prefix of an existing bind
+	assert_int_equal(BIND_CONFLICTS, bind_add(&bind, "a", "command"));
+
+	//Conflict if it's an extension of an existing bind
+	assert_int_equal(BIND_CONFLICTS, bind_add(&bind, "a b a", "command"));
+
+	destroy_bind(&bind);
+}
+
+static void test_translate_key_event(void **state)
+{
+	struct {
+		const char* str;
+		char ch;
+		int mod;
+		int key;
+	} pairs[] = {
+		{"a", 'a', 0, 0},
+		{"R", 'R', 0, 0},
+		{"9", '9', 0, 0},
+		{"Ctrl+a", 0, 0, TB_KEY_CTRL_A},
+		{"Left", 0, 0, TB_KEY_ARROW_LEFT},
+		{"Meta+q", 'q', TB_MOD_ALT, 0},
+		{"Meta+Right", 0, TB_MOD_ALT, TB_KEY_ARROW_RIGHT},
+		{"Meta+Eq", '=', TB_MOD_ALT, 0},
+		{"Space", ' ', 0, 0},
+		{"Meta+Space", ' ', TB_MOD_ALT, 0},
+	};
+
+	struct tb_event e;
+	memset(&e, 0, sizeof e);
+	for(size_t i = 0; i < sizeof pairs / sizeof pairs[0]; ++i) {
+		e = generate_event(pairs[i].ch, pairs[i].mod, pairs[i].key);
+		char* str = bind_translate_key_event(&e);
+		assert_string_equal(str, pairs[i].str);
+		free(str);
+	}
+}
+
+static void test_get_input_buffer(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b c", "alpha beta"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b d", "beta alpha"));
+
+	struct tb_event e;
+	e = generate_event('a', 0, 0);
+	bind_handle_key_event(&bind, &e);
+	e = generate_event('b', 0, 0);
+	bind_handle_key_event(&bind, &e);
+
+	char* input = bind_input_buffer(&bind);
+	assert_string_equal("a b", input);
+	free(input);
+
+	destroy_bind(&bind);
+}
+
+static void test_remember_binds(void **state)
+{
+	struct bind bind;
+	init_bind(&bind);
+
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b", "alpha beta"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "b a", "beta alpha"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Ctrl+x s", "save"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Meta+q", "quiet"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Ctrl+x o", "open"));
+
+	struct tb_event e;
+
+	//Test perfect input
+	e = generate_event('a', 0, 0);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+	e = generate_event('b', 0, 0);
+	assert_string_equal("alpha beta", bind_handle_key_event(&bind, &e));
+
+	//Test bad input retrieves nothing
+	e = generate_event('c', 0, 0);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+
+	//Test after bad input the buffer is clear for good input
+	e = generate_event(0, 0, TB_KEY_CTRL_X);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+	e = generate_event('s', 0, 0);
+	assert_string_equal("save", bind_handle_key_event(&bind, &e));
+
+	//Test hitting ESC clears the input state
+	e = generate_event('a', 0, 0);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+	e = generate_event(0, 0, TB_KEY_ESC);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+	e = generate_event('b', 0, 0);
+	assert_int_equal(NULL, bind_handle_key_event(&bind, &e));
+
+	destroy_bind(&bind);
+}
+
+int run_tests_bind() {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_reject_invalid_command),
+		cmocka_unit_test(test_reject_invalid_keys),
+		cmocka_unit_test(test_accept_valid_keys),
+		cmocka_unit_test(test_reject_conflicting_keys),
+		cmocka_unit_test(test_translate_key_event),
+		cmocka_unit_test(test_get_input_buffer),
+		cmocka_unit_test(test_remember_binds),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -16,6 +16,7 @@ int main(int argc, char **argv) {
 	ret += run_tests_urlparse();
 	ret += run_tests_imap();
 	ret += run_tests_headers();
+	ret += run_tests_bind();
 
 	return ret;
 }


### PR DESCRIPTION
This pull request creates a bind mapping subsystem (with unit tests), and integrates it into aerc. Some default binds are hardcoded, but can be overwritten in `aerc.conf`.

I'm a little uncertain about how I've named the bind mapping system, so if you have any better ideas, or other suggestions for improvements, I'm open to them.