### PR TITLE
Don't re-render between individual key-events

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -268,11 +268,6 @@ static void process_event(struct tb_event* event, aqueue_t *event_queue) {
 		}
 		break;
 	}
-
-	if(state->rerender) {
-		state->rerender = false;
-		rerender();
-	}
 }
 
 bool ui_tick() {
@@ -311,6 +306,11 @@ bool ui_tick() {
 		free(event);
 	}
 	aqueue_free(events);
+
+	if (state->rerender) {
+		state->rerender = false;
+		rerender();
+	}
 
 	return !state->exit;
 }


### PR DESCRIPTION
Currently aerc re-renders between every key-press, which is expensive when handling a bind that runs a command. Instead, re-render once per event queue iteration.

This was an oversight from the previous patch, which only prevent multiple-renders within a single input event.