### PR TITLE
Rework bind system to match output command format

### DIFF
--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -72,7 +72,7 @@ j = :next-message<Enter>
 <WheelDown> = :next-message --scroll 1<Enter>
 
 k = :previous-message<Enter>
-Up = :previous-message<Enter>
+<Up> = :previous-message<Enter>
 <Ctrl+u> = :previous-message --scroll 50%<Enter>
 <Ctrl+b> = :previous-message --scroll 100%<Enter>
 <PageUp> = :previous-message --scroll 100%<Enter>

--- a/config/aerc.conf
+++ b/config/aerc.conf
@@ -53,33 +53,33 @@ sidebar-width=20
 [lbinds]
 #
 # Binds are of the form <key sequence> = <command to run>
-# To use '=' in a key sequence, substitute it with "Eq": "Ctrl+Eq"
+# To use '=' in a key sequence, substitute it with "Eq": "<Ctrl+Eq>"
 # If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit
 #
 # lbinds are bindings that take effect in the list view
 # mbinds are bindings that take effect in the message view
 q = :quit<Enter>
-Ctrl+c = :quit<Enter>
+<Ctrl+c> = :quit<Enter>
 
 h = :previous-mailbox<Enter>
-Left = :previous-mailbox<Enter>
+<Left> = :previous-mailbox<Enter>
 
 j = :next-message<Enter>
-Down = :next-message<Enter>
-Ctrl+d = :next-message --scroll 50%<Enter>
-Ctrl+f = :next-message --scroll 100%<Enter>
-PageDown = :next-message --scroll 100%<Enter>
-WheelDown = :next-message --scroll 1<Enter>
+<Down> = :next-message<Enter>
+<Ctrl+d> = :next-message --scroll 50%<Enter>
+<Ctrl+f> = :next-message --scroll 100%<Enter>
+<PageDown> = :next-message --scroll 100%<Enter>
+<WheelDown> = :next-message --scroll 1<Enter>
 
 k = :previous-message<Enter>
 Up = :previous-message<Enter>
-Ctrl+u = :previous-message --scroll 50%<Enter>
-Ctrl+b = :previous-message --scroll 100%<Enter>
-PageUp = :previous-message --scroll 100%<Enter>
-WheelUp = :previous-message --scroll 1<Enter>
+<Ctrl+u> = :previous-message --scroll 50%<Enter>
+<Ctrl+b> = :previous-message --scroll 100%<Enter>
+<PageUp> = :previous-message --scroll 100%<Enter>
+<WheelUp> = :previous-message --scroll 1<Enter>
 
 l = :next-mailbox<Enter>
-Right = :next-mailbox<Enter>
+<Right> = :next-mailbox<Enter>
 
 J = :next-folder<Enter>
 K = :previous-folder<Enter>

--- a/src/bind.c
+++ b/src/bind.c
@@ -128,7 +128,7 @@ void add_default_bindings(struct bind *binds) {
 	bind_add(binds, "<WheelDown>", ":next-message --scroll 1<Enter>");
 
 	bind_add(binds, "k", ":previous-message<Enter>");
-	bind_add(binds, "Up", ":previous-message<Enter>");
+	bind_add(binds, "<Up>", ":previous-message<Enter>");
 	bind_add(binds, "<Ctrl+u>", ":previous-message --scroll 50%<Enter>");
 	bind_add(binds, "<PageUp>", ":previous-message --scroll 100%<Enter>");
 	bind_add(binds, "<WheelUp>", ":previous-message --scroll 1<Enter>");

--- a/src/bind.c
+++ b/src/bind.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 201112LL
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -115,25 +116,25 @@ static const struct {
 
 void add_default_bindings(struct bind *binds) {
 	bind_add(binds, "q", ":quit<Enter>");
-	bind_add(binds, "Ctrl+c", ":quit<Enter>");
+	bind_add(binds, "<Ctrl+c>", ":quit<Enter>");
 
 	bind_add(binds, "h", ":previous-mailbox<Enter>");
-	bind_add(binds, "Left", ":previous-mailbox<Enter>");
+	bind_add(binds, "<Left>", ":previous-mailbox<Enter>");
 
 	bind_add(binds, "j", ":next-message<Enter>");
-	bind_add(binds, "Down", ":next-message<Enter>");
-	bind_add(binds, "Ctrl+d", ":next-message --scroll 50%<Enter>");
-	bind_add(binds, "PageDown", ":next-message --scroll 100%<Enter>");
-	bind_add(binds, "WheelDown", ":next-message --scroll 1<Enter>");
+	bind_add(binds, "<Down>", ":next-message<Enter>");
+	bind_add(binds, "<Ctrl+d>", ":next-message --scroll 50%<Enter>");
+	bind_add(binds, "<PageDown>", ":next-message --scroll 100%<Enter>");
+	bind_add(binds, "<WheelDown>", ":next-message --scroll 1<Enter>");
 
 	bind_add(binds, "k", ":previous-message<Enter>");
 	bind_add(binds, "Up", ":previous-message<Enter>");
-	bind_add(binds, "Ctrl+u", ":previous-message --scroll 50%<Enter>");
-	bind_add(binds, "PageUp", ":previous-message --scroll 100%<Enter>");
-	bind_add(binds, "WheelUp", ":previous-message --scroll 1<Enter>");
+	bind_add(binds, "<Ctrl+u>", ":previous-message --scroll 50%<Enter>");
+	bind_add(binds, "<PageUp>", ":previous-message --scroll 100%<Enter>");
+	bind_add(binds, "<WheelUp>", ":previous-message --scroll 1<Enter>");
 
 	bind_add(binds, "l", ":next-mailbox<Enter>");
-	bind_add(binds, "Right", ":next-mailbox<Enter>");
+	bind_add(binds, "<Right>", ":next-mailbox<Enter>");
 
 	bind_add(binds, "J", ":next-folder<Enter>");
 	bind_add(binds, "K", ":previous-folder<Enter>");
@@ -202,13 +203,67 @@ static int is_valid_key(const char *key) {
 	return 0;
 }
 
+static bool is_valid_special_key(const char* key) {
+	const size_t len = sizeof(key_name_pairs) / sizeof(*key_name_pairs);
+	for (size_t i = 0; i < len; ++i) {
+		if (!strcmp(key, key_name_pairs[i].name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static list_t *split_bind(const char* str) {
+	list_t *list = create_list();
+	// Iterate through the string, breaking it into its parts
+	while(*str) {
+		if (*str == '<') {
+			// Is this a special key?
+			const char* end = str;
+			while(*end && *end != '>')
+				++end;
+			if (*end == '>') {
+				// We've got a <stuff> block. Check if it's a valid special key name.
+				const size_t key_len = end - str;
+				char* key = malloc(key_len);
+				memcpy(key, str + 1 /* skip the '<' */, key_len - 1);
+				key[key_len] = 0;
+
+				if (is_valid_special_key(key)) {
+					list_add(list, key);
+					str = end + 1;
+					continue;
+				} else {
+					free(key);
+				}
+			}
+		}
+
+		if (isgraph(*str)) {
+			// Just a regular character?
+			char* item = malloc(2);
+			item[0] = *str;
+			item[1] = 0;
+			list_add(list, item);
+			++str;
+			continue;
+		}
+
+		// Reached this point? It's something weird. Ignore it for now.
+		++str;
+	}
+
+	return list;
+}
+
+
 static int is_valid_keys(const char *keys) {
 	if (!keys || strlen(keys) == 0) {
 		return 0;
 	}
 
 	int valid = 1;
-	list_t *parts = split_string(keys, " ");
+	list_t *parts = split_bind(keys);
 
 	for (size_t i = 0; i < parts->length; ++i) {
 		if (!is_valid_key(parts->items[i])) {
@@ -254,7 +309,7 @@ enum bind_result bind_add(struct bind* bind, const char* keys, const char* comma
 	}
 
 	// Split the key up into its individual parts
-	list_t *parts = split_string(dirty_keys, " ");
+	list_t *parts = split_bind(dirty_keys);
 
 	//Prepare our return code
 	int result = BIND_SUCCESS;
@@ -382,7 +437,7 @@ static enum lookup_result lookup_binding(struct bind_node *node, list_t *keys, c
 }
 
 char* bind_input_buffer(struct bind *bind) {
-	return join_list(bind->keys, " ");
+	return join_list(bind->keys, NULL);
 }
 
 static void clear_input_buffer(struct bind *bind) {

--- a/src/util/stringop.c
+++ b/src/util/stringop.c
@@ -181,7 +181,7 @@ char *join_list(list_t *list, char *separator) {
 		len += strlen(list->items[i]);
 	}
 
-	if(len == 0) {
+	if(list->length == 0) {
 		return strdup("");
 	}
 

--- a/test/bind.c
+++ b/test/bind.c
@@ -22,18 +22,14 @@ static void test_reject_invalid_command(void **state) {
 	destroy_bind(&bind);
 }
 
-static void test_reject_invalid_keys(void **state) {
+static void test_reject_invalid_binds(void **state) {
 	struct bind bind;
 	init_bind(&bind);
 
 	static const char *keys[] = {
 		"Ctrl+=",
-		"foobar",
 		"=",
 		"",
-		"Shift+W",
-		"Shift+Eq",
-		"Ctrl+Ctrl+x",
 	};
 
 	for (size_t i = 0; i < sizeof keys / sizeof keys[0]; ++i) {
@@ -43,27 +39,27 @@ static void test_reject_invalid_keys(void **state) {
 	destroy_bind(&bind);
 }
 
-static void test_accept_valid_keys(void **state) {
+static void test_accept_valid_binds(void **state) {
 	struct bind bind;
 	init_bind(&bind);
 
 	static const char *keys[] = {
-		"Ctrl+q",
-		"Ctrl+E",
-		"Meta+!",
-		"Space",
-		"Ctrl++",
-		"Ctrl+Eq",
-		"# 2",
-		"Ctrl+x s",
-		"Ctrl+x z",
+		"<Ctrl+q>",
+		"<Ctrl+E>",
+		"<Meta+!>",
+		"<Space>",
+		"<Ctrl++>",
+		"<Ctrl+Eq>",
+		"#2",
+		"<Ctrl+x>s",
+		"<Ctrl+x>z",
 		"s",
 		"W",
-		"Ctrl+Meta+Delete",
+		"<Ctrl+Meta+Delete>",
 		";",
-		"F1",
-		"Meta+Backspace",
-		"Shift+Left",
+		"<F1>",
+		"<Meta+Backspace>",
+		"<Shift+Left>",
 	};
 
 	for (size_t i = 0; i < sizeof keys / sizeof keys[0]; ++i) {
@@ -73,17 +69,17 @@ static void test_accept_valid_keys(void **state) {
 	destroy_bind(&bind);
 }
 
-static void test_reject_conflicting_keys(void **state) {
+static void test_reject_conflicting_binds(void **state) {
 	struct bind bind;
 	init_bind(&bind);
 
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b", "command"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "ab", "command"));
 
 	//Conflict if it's a prefix of an existing bind
 	assert_int_equal(BIND_CONFLICTS, bind_add(&bind, "a", "command"));
 
 	//Conflict if it's an extension of an existing bind
-	assert_int_equal(BIND_CONFLICTS, bind_add(&bind, "a b a", "command"));
+	assert_int_equal(BIND_CONFLICTS, bind_add(&bind, "aba", "command"));
 
 	destroy_bind(&bind);
 }
@@ -150,8 +146,8 @@ static void test_get_input_buffer(void **state) {
 	struct bind bind;
 	init_bind(&bind);
 
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b c", "alpha beta"));
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b d", "beta alpha"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "abc", "alpha beta"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "abd", "beta alpha"));
 
 	struct tb_event e;
 	e = generate_event('a', 0, 0);
@@ -160,7 +156,7 @@ static void test_get_input_buffer(void **state) {
 	bind_handle_key_event(&bind, &e);
 
 	char *input = bind_input_buffer(&bind);
-	assert_string_equal("a b", input);
+	assert_string_equal("ab", input);
 	free(input);
 
 	destroy_bind(&bind);
@@ -170,11 +166,11 @@ static void test_remember_binds(void **state) {
 	struct bind bind;
 	init_bind(&bind);
 
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "a b", "alpha beta"));
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "b a", "beta alpha"));
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Ctrl+x s", "save"));
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Meta+q", "quiet"));
-	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "Ctrl+x o", "open"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "ab", "alpha beta"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "ba", "beta alpha"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "<Ctrl+x>s", "save"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "<Meta+q>", "quiet"));
+	assert_int_equal(BIND_SUCCESS, bind_add(&bind, "<Ctrl+x>o", "open"));
 
 	struct tb_event e;
 
@@ -209,9 +205,9 @@ static void test_remember_binds(void **state) {
 int run_tests_bind() {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_reject_invalid_command),
-		cmocka_unit_test(test_reject_invalid_keys),
-		cmocka_unit_test(test_accept_valid_keys),
-		cmocka_unit_test(test_reject_conflicting_keys),
+		cmocka_unit_test(test_reject_invalid_binds),
+		cmocka_unit_test(test_accept_valid_binds),
+		cmocka_unit_test(test_reject_conflicting_binds),
 		cmocka_unit_test(test_translate_key_event),
 		cmocka_unit_test(test_translate_key_name),
 		cmocka_unit_test(test_get_input_buffer),


### PR DESCRIPTION
Instead of each key being space separated, e.g. `Ctrl+a b`, we now use the same format as the output commands for binds, e.g. `<Ctrl+a>b`.