### PR TITLE
Handle flag change on unfetched messages

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -163,7 +163,6 @@ void handle_worker_message_updated(struct account_state *account,
 		struct aerc_message *old = mbox->messages->items[i];
 		if (old->index == new->index) {
 			free_aerc_message(mbox->messages->items[i]);
-			new->fetched = true;
 			mbox->messages->items[i] = new;
 			rerender_item(i);
 			if (account->viewer.msg == old) {


### PR DESCRIPTION
With multiple IMAP accounts, the worker for the second account will connect, issue an IMAP SELECT for "INBOX", but not actually fetch the headers of messages. If another client on this account updates the
flags on a message, the server will send an IMAP FETCH. The fetch handler assumed that whenever the server sent a FETCH, the message would be fully populated, which is incorrect in this case.

To handle this, we consider a message fully populated when all the handlers for fetched elements are fired in a single message (i.e. UID, FLAGS, INTERNALDATE, BODYSTRUCTURE and BODY). This may not be sufficient to guarantee that the message is indeed populated with all required headers.

Additionally, a message was always considered to be populated when the IMAP backend notifies the frontend of an update. We instead listen to the message's own determination of whether it is populated or not.